### PR TITLE
Add scheduled output to crypto market news example

### DIFF
--- a/examples/crypto_market_news/README.md
+++ b/examples/crypto_market_news/README.md
@@ -2,7 +2,8 @@
 
 This example demonstrates using the Agents SDK to gather the latest market news on
 Ethereum (ETH) and Bitcoin (BTC). It performs two web searches in parallel and
-then compiles a short report.
+then compiles a short report. The workflow now runs every ten minutes and
+saves each markdown report to the `outputs` directory.
 
 Run it with:
 

--- a/examples/crypto_market_news/agents/search_agent.py
+++ b/examples/crypto_market_news/agents/search_agent.py
@@ -10,5 +10,6 @@ search_agent = Agent(
     name="CryptoSearchAgent",
     instructions=INSTRUCTIONS,
     tools=[WebSearchTool()],
+    model="gpt-4.1",
     model_settings=ModelSettings(tool_choice="required"),
 )

--- a/examples/crypto_market_news/agents/writer_agent.py
+++ b/examples/crypto_market_news/agents/writer_agent.py
@@ -3,13 +3,13 @@ from pydantic import BaseModel
 from agents import Agent
 
 PROMPT = (
-    "You are a crypto market analyst tasked with writing a concise report"\
-    " about current events in the Ethereum and Bitcoin markets. You will"\
-    " be provided with search summaries for ETH and BTC. Create a short"\
-    " 2-3 sentence overview and a longer markdown report highlighting"\
-    " notable trends, price movements, and any significant regulatory or"\
-    " adoption news. Provide two or three follow-up questions for further"\
-    " investigation."
+    "You are a crypto market analyst tasked with writing a concise and "
+    "straight-to-the-point report about current events in the Ethereum and "
+    "Bitcoin markets. You will be provided with search summaries for ETH and "
+    "BTC. Create a short 2-3 sentence overview and a brief markdown report "
+    "highlighting notable trends, price movements, and key regulatory or "
+    "adoption news. Provide two or three follow-up questions for further "
+    "investigation."
 )
 
 
@@ -22,6 +22,6 @@ class CryptoReport(BaseModel):
 writer_agent = Agent(
     name="CryptoWriterAgent",
     instructions=PROMPT,
-    model="o3-mini",
+    model="gpt-4.1",
     output_type=CryptoReport,
 )

--- a/examples/crypto_market_news/main.py
+++ b/examples/crypto_market_news/main.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import timedelta
 from dotenv import load_dotenv
 
 load_dotenv()  # Load environment variables from .env file
@@ -6,8 +7,15 @@ load_dotenv()  # Load environment variables from .env file
 from .manager import CryptoNewsManager
 
 
+async def run_periodically(interval: timedelta) -> None:
+    """Run the crypto news workflow on a schedule."""
+    while True:
+        await CryptoNewsManager().run()
+        await asyncio.sleep(interval.total_seconds())
+
+
 async def main() -> None:
-    await CryptoNewsManager().run()
+    await run_periodically(timedelta(minutes=10))
 
 
 if __name__ == "__main__":

--- a/examples/crypto_market_news/manager.py
+++ b/examples/crypto_market_news/manager.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime
+from pathlib import Path
 
 from rich.console import Console
 
@@ -50,6 +52,16 @@ class CryptoNewsManager:
         print("\n\n=====FOLLOW UP QUESTIONS=====\n\n")
         follow_up_questions = "\n".join(report.follow_up_questions)
         print(f"Follow up questions: {follow_up_questions}")
+
+        output_dir = Path(__file__).parent / "outputs"
+        output_dir.mkdir(exist_ok=True)
+        filename = output_dir / f"crypto_news_{datetime.now().strftime('%Y%m%d_%H%M%S')}.md"
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write(report.markdown_report)
+            f.write("\n\nFollow up questions:\n")
+            for q in report.follow_up_questions:
+                f.write(f"- {q}\n")
+        print(f"Saved report to {filename}")
 
     async def _perform_searches(self, search_terms: list[str]) -> list[str]:
         with custom_span("Search the web"):


### PR DESCRIPTION
## Summary
- run the crypto market news workflow every 10 minutes
- use `gpt-4.1` for both search and writer agents
- update writer instructions for a concise report
- save reports to an `outputs` directory
- document new behaviour in the README

## Testing
- `pytest`
- `python -m examples.crypto_market_news.main` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68403c17b71883259968fc85c708cae6