### PR TITLE
Overwrite crypto news report as JSON

### DIFF
--- a/examples/crypto_market_news/README.md
+++ b/examples/crypto_market_news/README.md
@@ -3,7 +3,7 @@
 This example demonstrates using the Agents SDK to gather the latest market news on
 Ethereum (ETH) and Bitcoin (BTC). It performs two web searches in parallel and
 then compiles a short report. The workflow now runs every ten minutes and
-saves each markdown report to the `outputs` directory.
+overwrites a `crypto_news.json` file in the `outputs` directory with the latest report.
 
 Run it with:
 

--- a/examples/crypto_market_news/manager.py
+++ b/examples/crypto_market_news/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from datetime import datetime
 from pathlib import Path
@@ -55,12 +56,14 @@ class CryptoNewsManager:
 
         output_dir = Path(__file__).parent / "outputs"
         output_dir.mkdir(exist_ok=True)
-        filename = output_dir / f"crypto_news_{datetime.now().strftime('%Y%m%d_%H%M%S')}.md"
+        filename = output_dir / "crypto_news.json"
+        data = {
+            "short_summary": report.short_summary,
+            "markdown_report": report.markdown_report,
+            "follow_up_questions": report.follow_up_questions,
+        }
         with open(filename, "w", encoding="utf-8") as f:
-            f.write(report.markdown_report)
-            f.write("\n\nFollow up questions:\n")
-            for q in report.follow_up_questions:
-                f.write(f"- {q}\n")
+            json.dump(data, f, indent=2)
         print(f"Saved report to {filename}")
 
     async def _perform_searches(self, search_terms: list[str]) -> list[str]:


### PR DESCRIPTION
## Summary
- modify crypto news workflow so output is written to a single JSON file
- update README to mention the JSON report overwrite

## Testing
- `pytest -q`
- `python -m py_compile examples/crypto_market_news/manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68405dce73b08325bf18900f4177671e